### PR TITLE
Let init_plans add new plans if some already exist

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -90,6 +90,8 @@ Configuration (Modifications to `settings.py`)
         },
     }
 
+* If you're using Stripe to send email receipts for you, set ``SEND_EMAIL_RECEIPTS = False`` (and configure your emails from your Stripe Account Settings).  Alternatively ``payments`` can send them for you - you'll want to set ``PAYMENTS_INVOICE_FROM_EMAIL`` to the email address that your receipts will be sent from.
+
 
 Static Media
 ============

--- a/payments/management/commands/init_plans.py
+++ b/payments/management/commands/init_plans.py
@@ -20,13 +20,19 @@ class Command(BaseCommand):
                 else:
                     amount = int(100 * decimal.Decimal(str(price)))
 
-                stripe.Plan.create(
-                    amount=amount,
-                    interval=settings.PAYMENTS_PLANS[plan]["interval"],
-                    name=settings.PAYMENTS_PLANS[plan]["name"],
-                    currency=settings.PAYMENTS_PLANS[plan]["currency"],
-                    trial_period_days=settings.PAYMENTS_PLANS[plan].get(
-                        "trial_period_days"),
-                    id=settings.PAYMENTS_PLANS[plan].get("stripe_plan_id")
-                )
-                print("Plan created for {0}".format(plan))
+                try:
+                    plan_name = settings.PAYMENTS_PLANS[plan]["name"]
+                    plan_id = settings.PAYMENTS_PLANS[plan].get("stripe_plan_id")
+
+                    stripe.Plan.create(
+                        amount=amount,
+                        interval=settings.PAYMENTS_PLANS[plan]["interval"],
+                        name=plan_name,
+                        currency=settings.PAYMENTS_PLANS[plan]["currency"],
+                        trial_period_days=settings.PAYMENTS_PLANS[plan].get(
+                            "trial_period_days"),
+                        id=plan_id
+                    )
+                    print("Plan created for {0}".format(plan))
+                except Exception as e:
+                    print "{0} ({1}): {2}".format(plan_name, plan_id, e)

--- a/payments/management/commands/init_plans.py
+++ b/payments/management/commands/init_plans.py
@@ -35,4 +35,4 @@ class Command(BaseCommand):
                     )
                     print("Plan created for {0}".format(plan))
                 except Exception as e:
-                    print "{0} ({1}): {2}".format(plan_name, plan_id, e)
+                    print("{0} ({1}): {2}".format(plan_name, plan_id, e))


### PR DESCRIPTION
I didn't get pull all my proposed plans into settings.py the first time, so I've changed init_plans so it copes with adding new ones and skipping over existing ones