### PR TITLE
Changing use of smart_str to smart_str for Customer.__unicode__

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -9,6 +9,7 @@ from django.core.mail import EmailMessage
 from django.db import models
 from django.utils import timezone
 from django.utils.encoding import smart_str
+from django.utils.encoding import smart_text
 from django.template.loader import render_to_string
 
 from django.contrib.sites.models import Site
@@ -318,7 +319,7 @@ class Customer(StripeObject):
     objects = CustomerManager()
 
     def __unicode__(self):
-        return smart_str(self.user)
+        return smart_text(self.user)
 
     @property
     def stripe_customer(self):


### PR DESCRIPTION
I've got an international user base with a lot of unicode names. The Customer.unicode method currently breaks when a user has unicode characters in their name. This is because Django's utility method which Customer.unicode currently uses, smart_str, returns a byte sequence and not unicode. Not only does this break when rendering a Customer object in a template, it's very unexpected behaviour to call unicode on an object and not get unicode back.

My change uses smart_text instead, which in py2 returns a unicode string and in py3 a normal str, which by default is unicode. It's been around earlier than 1.6, which is now the minimum version supported for this project.